### PR TITLE
feat: add `shiftheadinglevelsby` option

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -36,6 +36,10 @@ inputs:
     description: "Use treesitter for highlighting codeblocks"
     required: false
     default: "false"
+  shiftheadinglevelsby:
+    description: "Shift heading levels by specified number"
+    required: false
+    default: "0"
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -47,3 +51,4 @@ runs:
     - ${{ inputs.description }}
     - ${{ inputs.demojify }}
     - ${{ inputs.treesitter }}
+    - ${{ inputs.shiftheadinglevelsby }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,7 @@ ARGS=(
 "--metadata=description:$5"
 "--metadata=dedupsubheadings:$6"
 "--metadata=treesitter:$7"
+"--shift-heading-level-by=$8"
 "--lua-filter=/scripts/skip-blocks.lua"
 "--lua-filter=/scripts/include-files.lua"
 )


### PR DESCRIPTION
This option shifts heading levels by specified number. Does so by adding the specified number to all of the header levels. I need this for my project, because all of the headings except the first one (which is ignored) are level 2 or lower there.

[Source](https://pandoc.org/MANUAL.html#reader-options)