### PR TITLE
Improve script for manual use

### DIFF
--- a/panvimdoc.sh
+++ b/panvimdoc.sh
@@ -4,22 +4,24 @@ set -euo pipefail
 
 # Check if the script was called with no arguments and show help in that case
 if [ $# -eq 0 ]; then
-  echo "Usage: $0 --project-name PROJECT_NAME --input-file INPUT_FILE --vim-version VIM_VERSION --toc TOC --description DESCRIPTION --dedup-subheadings DEDUP_SUBHEADINGS --treesitter TREESITTER"
-  echo ""
-  echo "Arguments:"
-  echo "  --project-name: the name of the project"
-  echo "  --input-file: the input markdown file"
-  echo "  --vim-version: the version of Vim that the project is compatible with"
-  echo "  --toc: 'true' if the output should include a table of contents, 'false' otherwise"
-  echo "  --description: a description of the project"
-  echo "  --dedup-subheadings: 'true' if duplicate subheadings should be removed, 'false' otherwise"
-  echo "  --demojify: 'false' if emojis should not be removed, 'true' otherwise"
-  echo "  --treesitter: 'true' if the project uses Tree-sitter syntax highlighting, 'false' otherwise"
-  echo "  --ignore-rawblocks: 'true' if the project should ignore HTML raw blocks, 'false' otherwise"
-  echo "  --doc-mapping: 'false' if h4 headings should double as mapping docs, 'true' otherwise"
-  echo "  --doc-mapping-project-name: 'true' if tags generated for mapping docs contain project name, 'false' otherwise"
-  echo "  --shift-heading-level-by: 0 if you don't want to shift heading levels , n otherwise"
-  echo "  --increment-heading-level-by: 0 if don't want to increment the starting heading number, n otherwise"
+    cat <<EOF
+Usage: $0 --project-name PROJECT_NAME --input-file INPUT_FILE --vim-version VIM_VERSION --toc TOC --description DESCRIPTION --dedup-subheadings DEDUP_SUBHEADINGS --treesitter TREESITTER
+
+Arguments:
+  --project-name: the name of the project
+  --input-file: the input markdown file
+  --vim-version: the version of Vim that the project is compatible with
+  --toc: 'true' if the output should include a table of contents, 'false' otherwise
+  --description: a description of the project
+  --dedup-subheadings: 'true' if duplicate subheadings should be removed, 'false' otherwise
+  --demojify: 'false' if emojis should not be removed, 'true' otherwise
+  --treesitter: 'true' if the project uses Tree-sitter syntax highlighting, 'false' otherwise
+  --ignore-rawblocks: 'true' if the project should ignore HTML raw blocks, 'false' otherwise
+  --doc-mapping: 'false' if h4 headings should double as mapping docs, 'true' otherwise
+  --doc-mapping-project-name: 'true' if tags generated for mapping docs contain project name, 'false' otherwise
+  --shift-heading-level-by: 0 if you don't want to shift heading levels , n otherwise
+  --increment-heading-level-by: 0 if don't want to increment the starting heading number, n otherwise
+EOF
   exit 1
 fi
 

--- a/panvimdoc.sh
+++ b/panvimdoc.sh
@@ -22,7 +22,7 @@ Arguments:
   --shift-heading-level-by: 0 if you don't want to shift heading levels , n otherwise
   --increment-heading-level-by: 0 if don't want to increment the starting heading number, n otherwise
 EOF
-  exit 1
+  exit 0
 fi
 
 # Parse command line arguments

--- a/panvimdoc.sh
+++ b/panvimdoc.sh
@@ -117,23 +117,23 @@ fi
 
 # Define arguments in an array
 ARGS=(
-    "--shift-heading-level-by=$SHIFT_HEADING_LEVEL_BY"
+    "--shift-heading-level-by=${SHIFT_HEADING_LEVEL_BY:-0}"
     "--metadata=project:$PROJECT_NAME"
-    "--metadata=vimversion:$VIM_VERSION"
-    "--metadata=toc:$TOC"
-    "--metadata=description:$DESCRIPTION"
-    "--metadata=dedupsubheadings:$DEDUP_SUBHEADINGS"
-    "--metadata=ignorerawblocks:$IGNORE_RAWBLOCKS"
-    "--metadata=docmapping:$DOC_MAPPING"
-    "--metadata=docmappingproject:$DOC_MAPPING_PROJECT_NAME"
-    "--metadata=treesitter:$TREESITTER"
-    "--metadata=incrementheadinglevelby:$INCREMENT_HEADING_LEVEL_BY"
+    "--metadata=vimversion:${VIM_VERSION:-""}"
+    "--metadata=toc:${TOC:-true}"
+    "--metadata=description:${DESCRIPTION:-""}"
+    "--metadata=dedupsubheadings:${DEDUP_SUBHEADINGS:-true}"
+    "--metadata=ignorerawblocks:${IGNORE_RAWBLOCKS:-true}"
+    "--metadata=docmapping:${DOC_MAPPING:-false}"
+    "--metadata=docmappingproject:${DOC_MAPPING_PROJECT_NAME:-true}"
+    "--metadata=treesitter:${TREESITTER:-true}"
+    "--metadata=incrementheadinglevelby:${INCREMENT_HEADING_LEVEL_BY:-0}"
     "--lua-filter=$SCRIPTS_DIR/skip-blocks.lua"
     "--lua-filter=$SCRIPTS_DIR/include-files.lua"
 )
 
 # Add an additional lua filter if demojify is true
-if [[ $DEMOJIFY == "true" ]]; then
+if [[ ${DEMOJIFY:-false} == "true" ]]; then
     ARGS+=(
         "--lua-filter=$SCRIPTS_DIR/remove-emojis.lua"
     )

--- a/panvimdoc.sh
+++ b/panvimdoc.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 set -euo pipefail
 
 # Check if the script was called with no arguments and show help in that case

--- a/panvimdoc.sh
+++ b/panvimdoc.sh
@@ -22,85 +22,84 @@ Arguments:
   --shift-heading-level-by: 0 if you don't want to shift heading levels , n otherwise
   --increment-heading-level-by: 0 if don't want to increment the starting heading number, n otherwise
 EOF
-  exit 0
+    exit 0
 fi
 
 # Parse command line arguments
-while [[ $# -gt 0 ]]
-do
-key="$1"
+while [[ $# -gt 0 ]]; do
+    key="$1"
 
-case $key in
+    case $key in
     --project-name)
-    PROJECT_NAME="$2"
-    shift # past argument
-    shift # past value
-    ;;
+        PROJECT_NAME="$2"
+        shift # past argument
+        shift # past value
+        ;;
     --input-file)
-    INPUT_FILE="$2"
-    shift # past argument
-    shift # past value
-    ;;
+        INPUT_FILE="$2"
+        shift # past argument
+        shift # past value
+        ;;
     --vim-version)
-    VIM_VERSION="$2"
-    shift # past argument
-    shift # past value
-    ;;
+        VIM_VERSION="$2"
+        shift # past argument
+        shift # past value
+        ;;
     --toc)
-    TOC="$2"
-    shift # past argument
-    shift # past value
-    ;;
+        TOC="$2"
+        shift # past argument
+        shift # past value
+        ;;
     --description)
-    DESCRIPTION="$2"
-    shift # past argument
-    shift # past value
-    ;;
+        DESCRIPTION="$2"
+        shift # past argument
+        shift # past value
+        ;;
     --dedup-subheadings)
-    DEDUP_SUBHEADINGS="$2"
-    shift # past argument
-    shift # past value
-    ;;
+        DEDUP_SUBHEADINGS="$2"
+        shift # past argument
+        shift # past value
+        ;;
     --ignore-rawblocks)
-    IGNORE_RAWBLOCKS="$2"
-    shift # past argument
-    shift # past value
-    ;;
+        IGNORE_RAWBLOCKS="$2"
+        shift # past argument
+        shift # past value
+        ;;
     --doc-mapping)
-    DOC_MAPPING="$2"
-    shift # past argument
-    shift # past value
-    ;;
+        DOC_MAPPING="$2"
+        shift # past argument
+        shift # past value
+        ;;
     --doc-mapping-project-name)
-    DOC_MAPPING_PROJECT_NAME="$2"
-    shift # past argument
-    shift # past value
-    ;;
+        DOC_MAPPING_PROJECT_NAME="$2"
+        shift # past argument
+        shift # past value
+        ;;
     --demojify)
-    DEMOJIFY="$2"
-    shift # past argument
-    shift # past value
-    ;;
+        DEMOJIFY="$2"
+        shift # past argument
+        shift # past value
+        ;;
     --treesitter)
-    TREESITTER="$2"
-    shift # past argument
-    shift # past value
-    ;;
+        TREESITTER="$2"
+        shift # past argument
+        shift # past value
+        ;;
     --shift-heading-level-by)
-    SHIFT_HEADING_LEVEL_BY="$2"
-    shift # past argument
-    shift # past value
-    ;;
+        SHIFT_HEADING_LEVEL_BY="$2"
+        shift # past argument
+        shift # past value
+        ;;
     --increment-heading-level-by)
-    INCREMENT_HEADING_LEVEL_BY="$2"
-    shift # past argument
-    shift # past value
-    ;;
-    *)    # unknown option
-    echo "Unknown option: $1"
-    exit 1
-    ;;
-esac
+        INCREMENT_HEADING_LEVEL_BY="$2"
+        shift # past argument
+        shift # past value
+        ;;
+    *) # unknown option
+        echo "Unknown option: $1"
+        exit 1
+        ;;
+    esac
 done
 
 # Check if /scripts directory exists
@@ -112,8 +111,8 @@ fi
 
 # If the scripts folder doesn't exist, throw an error
 if [ ! -d "$SCRIPTS_DIR" ]; then
-  printf "Error: $SCRIPTS_DIR directory not found.\n"
-  exit 1
+    printf "%s\n" "Error: $SCRIPTS_DIR directory not found."
+    exit 1
 fi
 
 # Define arguments in an array
@@ -134,10 +133,10 @@ ARGS=(
 )
 
 # Add an additional lua filter if demojify is true
-if [[ "$DEMOJIFY" = "true" ]]; then
-  ARGS+=(
-  "--lua-filter=$SCRIPTS_DIR/remove-emojis.lua"
-  )
+if [[ $DEMOJIFY == "true" ]]; then
+    ARGS+=(
+        "--lua-filter=$SCRIPTS_DIR/remove-emojis.lua"
+    )
 fi
 
 ARGS+=("-t" "$SCRIPTS_DIR/panvimdoc.lua")


### PR DESCRIPTION
This PR make the following change:
1. make the interpreter `usr/bin/env bash` to make it use wathever version the system has even installed in different places
2. instead of having a wall off echos, uses the much cleaner `EOF` to `cat`
3. make so the program exit without errors when display usage
4. format code for better styling
5. set default values if any value is given