### PR TITLE
fix: include project root in package.path so requires work

### DIFF
--- a/lib/init.lua
+++ b/lib/init.lua
@@ -1,0 +1,3 @@
+-- add project root to lua package path so requires work when the cwd is not
+-- the project root
+package.path = PANDOC_STATE.user_data_dir .. "/../?.lua;" .. package.path

--- a/panvimdoc.sh
+++ b/panvimdoc.sh
@@ -138,6 +138,7 @@ ARGS=(
 # Add an additional lua filter if demojify is true
 if [[ ${DEMOJIFY:-false} == "true" ]]; then
     ARGS+=(
+        "--data-dir=$SCRIPTS_DIR/../lib"
         "--lua-filter=$SCRIPTS_DIR/remove-emojis.lua"
     )
 fi


### PR DESCRIPTION
When the CWD is not the panvimdoc directory, `require("lib.Demojify")` would fail because lua cant find the file.

We add the data-dir argument when needed, setting it to the lib folder, which contains an init.lua file. This init.lua file prepends the project root to the package.path which allows `require("lib.Demojify")` to succeed.

The  `..` is a bit awkward, you might prefer to put the init.lua in the main project root instead and alter as needed. 