### PR TITLE
feat: convert `:h help-tag` into |help-tag|

### DIFF
--- a/doc/panvimdoc.md
+++ b/doc/panvimdoc.md
@@ -155,6 +155,10 @@ This is excluded from the links section.
 
 Lastly, if the markdown text is a url, the link is not added to the links section and instead is placed inline.
 
+## Linking to help tags
+
+Markdown doucments may suggest help tags via `:h help-tag`, which are converted to `|help-tag|` "hot links" in vimdoc.
+
 ## Mappings
 
 While you can use codeblocks with the language `vimdoc` to insert text in the generated vimdoc, it can be useful to have a markdown friendly way to write documentation for mappings.

--- a/scripts/panvimdoc.lua
+++ b/scripts/panvimdoc.lua
@@ -477,7 +477,13 @@ Writer.Inline.Image = function(el)
 end
 
 Writer.Inline.Code = function(el)
-  return "`" .. escape(stringify(el)) .. "`"
+  local content = stringify(el)
+  local vim_help = string.match(content, "^:h %s*([^%s]+)")
+  if vim_help then
+    return string.format("|%s|", escape(vim_help))
+  else
+    return "`" .. escape(content) .. "`"
+  end
 end
 
 Writer.Inline.Math = function(s)

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -142,6 +142,10 @@ there`
 
 there`
 
+## helptags
+
+This content includes a helptag for `:h :a-complex.messy-%tag` inbetween other text.
+
 ## Multilingual URLs
 
 <http://测.com?测=测>
@@ -509,6 +513,12 @@ CODE SPANS                                                   *test-code-spans*
 `hi
 
 there`
+
+
+HELPTAGS                                                       *test-helptags*
+
+This content includes a helptag for |:a-complex.messy-%tag| inbetween other
+text.
 
 
 MULTILINGUAL URLS                                     *test-multilingual-urls*


### PR DESCRIPTION
Markdown documents may contain "help-tag examples" in the form `:h some-topic`, which are converted to |some-topic| hot-links.