### PR TITLE
feat: add <!-- panvimdoc-only content --> support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
+        with:
+          version: 1.9
+          arch: x64
       - uses: julia-actions/julia-buildpkg@v1
       - name: Build Docker image
         run: docker build -t test-image .

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,12 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.8.5"
+julia_version = "1.9.2"
 manifest_format = "2.0"
 project_hash = "14665feaa1f642ac968d7a294ef475d6f1d69e4e"
-
-[[deps.ArgTools]]
-uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
-version = "1.1.1"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -15,15 +11,23 @@ uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[deps.Compat]]
-deps = ["Dates", "LinearAlgebra", "UUIDs"]
-git-tree-sha1 = "61fdd77467a5c3ad071ef8277ac6bd6af7dd4c04"
+deps = ["UUIDs"]
+git-tree-sha1 = "e460f044ca8b99be31d35fe54fc33a5c33dd8ed7"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.6.0"
+version = "4.9.0"
 
-[[deps.CompilerSupportLibraries_jll]]
-deps = ["Artifacts", "Libdl"]
-uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.0.1+0"
+    [deps.Compat.extensions]
+    CompatLinearAlgebraExt = "LinearAlgebra"
+
+    [deps.Compat.weakdeps]
+    Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+    LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[deps.DataStructures]]
+deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
+git-tree-sha1 = "3dbd312d370723b6bb43ba9d02fc36abade4518d"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.18.15"
 
 [[deps.Dates]]
 deps = ["Printf"]
@@ -38,10 +42,11 @@ version = "1.2.0"
 deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
-[[deps.Downloads]]
-deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
-uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
-version = "1.6.0"
+[[deps.DocStringExtensions]]
+deps = ["LibGit2"]
+git-tree-sha1 = "2fb1e02f2b635d0845df5d7c167fec4dd739b00d"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.9.3"
 
 [[deps.EnumX]]
 git-tree-sha1 = "bdb1942cd4c45e3c678fd11569d5cccd80976237"
@@ -53,9 +58,6 @@ deps = ["Compat", "Dates", "Mmap", "Printf", "Test", "UUIDs"]
 git-tree-sha1 = "e27c4ebe80e8699540f2d6c805cc12203b614f12"
 uuid = "48062228-2e41-5def-b9a4-89aafe57970f"
 version = "0.9.20"
-
-[[deps.FileWatching]]
-uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[deps.InlineTest]]
 deps = ["Test"]
@@ -74,36 +76,17 @@ uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 version = "1.4.1"
 
 [[deps.JSON3]]
-deps = ["Dates", "Mmap", "Parsers", "SnoopPrecompile", "StructTypes", "UUIDs"]
-git-tree-sha1 = "84b10656a41ef564c39d2d477d7236966d2b5683"
+deps = ["Dates", "Mmap", "Parsers", "PrecompileTools", "StructTypes", "UUIDs"]
+git-tree-sha1 = "95220473901735a0f4df9d1ca5b171b568b2daa3"
 uuid = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
-version = "1.12.0"
-
-[[deps.LibCURL]]
-deps = ["LibCURL_jll", "MozillaCACerts_jll"]
-uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
-version = "0.6.3"
-
-[[deps.LibCURL_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
-uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-version = "7.84.0+0"
+version = "1.13.2"
 
 [[deps.LibGit2]]
 deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
-[[deps.LibSSH2_jll]]
-deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
-uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
-version = "1.10.2+0"
-
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
-
-[[deps.LinearAlgebra]]
-deps = ["Libdl", "libblastrampoline_jll"]
-uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -118,57 +101,45 @@ version = "1.0.0"
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
-[[deps.MbedTLS_jll]]
-deps = ["Artifacts", "Libdl"]
-uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.0+0"
-
 [[deps.Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
-
-[[deps.MozillaCACerts_jll]]
-uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2022.2.1"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 version = "1.2.0"
 
-[[deps.OpenBLAS_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
-uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
-version = "0.3.20+0"
+[[deps.OrderedCollections]]
+git-tree-sha1 = "2e73fe17cac3c62ad1aebe70d44c963c3cfdc3e3"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.6.2"
 
 [[deps.Pandoc]]
-deps = ["EnumX", "FilePathsBase", "InlineTest", "JSON3", "Markdown", "ReTest", "StructTypes", "pandoc_jll"]
-git-tree-sha1 = "cd3072feec659c3ecace8d5aef2bdf6f69fc9c98"
+deps = ["DataStructures", "DocStringExtensions", "EnumX", "FilePathsBase", "InlineTest", "JSON3", "Markdown", "ReTest", "StructTypes", "pandoc_jll"]
+git-tree-sha1 = "51ffbad76bfc6f0dff3f2ba4e2e206587a94a5b7"
 uuid = "f853b5e0-b243-11e9-0043-7da5023c5ee7"
-version = "0.3.0"
+version = "0.4.3"
 
 [[deps.Parsers]]
-deps = ["Dates", "SnoopPrecompile"]
-git-tree-sha1 = "6f4fbcd1ad45905a5dee3f4256fabb49aa2110c6"
+deps = ["Dates", "PrecompileTools", "UUIDs"]
+git-tree-sha1 = "716e24b21538abc91f6205fd1d8363f39b442851"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.5.7"
+version = "2.7.2"
 
-[[deps.Pkg]]
-deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
-uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.8.0"
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "9673d39decc5feece56ef3940e5dafba15ba0f81"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.1.2"
 
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "47e5f437cc0e7ef2ce8406ce1e7e24d44915f88d"
+git-tree-sha1 = "7eb1686b4f04b82f96ed7a4ea5890a4f0c7a09f1"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.3.0"
+version = "1.4.0"
 
 [[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-
-[[deps.REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
-uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[deps.Random]]
 deps = ["SHA", "Serialization"]
@@ -187,12 +158,6 @@ version = "0.7.0"
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
-[[deps.SnoopPrecompile]]
-deps = ["Preferences"]
-git-tree-sha1 = "e760a70afdcd461cf01a575947738d359234665c"
-uuid = "66db9d55-30c0-4569-8b51-7e840670fc0c"
-version = "1.0.3"
-
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
@@ -205,12 +170,7 @@ version = "1.10.0"
 [[deps.TOML]]
 deps = ["Dates"]
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
-version = "1.0.0"
-
-[[deps.Tar]]
-deps = ["ArgTools", "SHA"]
-uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
-version = "1.10.1"
+version = "1.0.3"
 
 [[deps.Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
@@ -229,28 +189,8 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 [[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
-[[deps.Zlib_jll]]
-deps = ["Libdl"]
-uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.12+3"
-
-[[deps.libblastrampoline_jll]]
-deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
-uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
-version = "5.1.1+0"
-
-[[deps.nghttp2_jll]]
-deps = ["Artifacts", "Libdl"]
-uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
-version = "1.48.0+0"
-
-[[deps.p7zip_jll]]
-deps = ["Artifacts", "Libdl"]
-uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "17.4.0+0"
-
 [[deps.pandoc_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "bc780a533d96b0b5ca56e3d69ab528d36ad87084"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "a1cd90615d1ff32a0d4983e5af817ac6d5a504e2"
 uuid = "c5432543-76ad-5c9d-82bf-db097047a5e2"
-version = "3.0.1+0"
+version = "3.1.0+0"

--- a/doc/panvimdoc.md
+++ b/doc/panvimdoc.md
@@ -448,15 +448,15 @@ because it may cause the rest of your document to be ignored. Do this instead:
 
 Inversely to [markdown only content](#markdown-only-content), sometimes you want to show content only present in Vimdoc and hidden when viewed on Github.
 
-This can be placed inside `panvimdoc-include-comment-content` comments.
+This can be placed inside `panvimdoc-include-comment` comments.
 
 As with markdown only content, you must include a blank link before and after the comment.
 
-```
+```markdown
 
-<!-- panvimdoc-include-comment-content You can include single lines  -->
+<!-- panvimdoc-include-comment You can include single lines  -->
 
-<!-- panvimdoc-include-comment-content
+<!-- panvimdoc-include-comment
 
 Or multiple lines
 
@@ -474,9 +474,9 @@ Infact you can include any kind of content in the comment.
 
 ```
 
-<!-- panvimdoc-include-comment-content Neovim is a great text editor. -->
+<!-- panvimdoc-include-comment Neovim is a great text editor. -->
 
-<!-- panvimdoc-include-comment-content
+<!-- panvimdoc-include-comment
 
 Neovim supports `:h lua` plugins and is also:
 

--- a/doc/panvimdoc.md
+++ b/doc/panvimdoc.md
@@ -444,6 +444,47 @@ because it may cause the rest of your document to be ignored. Do this instead:
 <!-- panvimdoc-ignore-end -->
 ```
 
+## Vimdoc only content
+
+Inversely to [markdown only content](#markdown-only-content), sometimes you want to show content only present in Vimdoc and hidden when viewed on Github.
+
+This can be placed inside `panvimdoc-include-comment-content` comments.
+
+As with markdown only content, you must include a blank link before and after the comment.
+
+```
+
+<!-- panvimdoc-include-comment-content You can include single lines  -->
+
+<!-- panvimdoc-include-comment-content
+
+Or multiple lines
+
+- with other
+- content
+- types
+
+# And vimdoc only headings
+
+## That can include subheadings
+
+Infact you can include any kind of content in the comment.
+
+-->
+
+```
+
+<!-- panvimdoc-include-comment-content Neovim is a great text editor. -->
+
+<!-- panvimdoc-include-comment-content
+
+Neovim supports `:h lua` plugins and is also:
+
+- Multiplatform
+- Open source
+
+-->
+
 ## Details and summary
 
 You can even use `<details>` and `<summary>` tags for your README.md.

--- a/scripts/skip-blocks.lua
+++ b/scripts/skip-blocks.lua
@@ -40,10 +40,13 @@ function RawBlock(el)
     COMMENT = false
     return pandoc.List()
   end
-  if (string.starts_with(str, "<!-- panvimdoc-include-comment-content ") or
-    string.starts_with(str, "<!-- panvimdoc-include-comment-content\n"))
-    and string.ends_with(str, "-->") then
-    local content = string.match(str, "<!%-%- panvimdoc%-include%-comment%-content%s+(.+)%-%->")
+  if
+    (
+      string.starts_with(str, "<!-- panvimdoc-include-comment ")
+      or string.starts_with(str, "<!-- panvimdoc-include-comment\n")
+    ) and string.ends_with(str, "-->")
+  then
+    local content = string.match(str, "<!%-%- panvimdoc%-include%-comment%s+(.+)%-%->")
     return pandoc.read(content, "markdown").blocks
   end
   if string.starts_with(str, "<!--") then

--- a/scripts/skip-blocks.lua
+++ b/scripts/skip-blocks.lua
@@ -40,6 +40,12 @@ function RawBlock(el)
     COMMENT = false
     return pandoc.List()
   end
+  if (string.starts_with(str, "<!-- panvimdoc-include-comment-content ") or
+    string.starts_with(str, "<!-- panvimdoc-include-comment-content\n"))
+    and string.ends_with(str, "-->") then
+    local content = string.match(str, "<!%-%- panvimdoc%-include%-comment%-content%s+(.+)%-%->")
+    return pandoc.read(content, "markdown").blocks
+  end
   if string.starts_with(str, "<!--") then
     return pandoc.List()
   elseif COMMENT == true then

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -395,6 +395,25 @@ bar
 
 [*foo* bar baz [link](url)]{.class #id key=val}
 
+## panvimdoc-include-comment-content
+
+<!-- panvimdoc-include-comment-content Neovim is a great text editor. -->
+
+<!-- panvimdoc-include-comment-content
+
+Neovim supports `:h lua` plugins and is also:
+
+- Multiplatform
+- Open source
+
+## All Content Types
+
+### Are supported
+
+See [neovim.org](https://neovim.org).
+
+-->
+
     """;
     toc = false,
     demojify = true,
@@ -762,6 +781,24 @@ WRAPPING                                                       *test-wrapping*
 BRACKETED SPANS                                         *test-bracketed-spans*
 
 _foo_ bar baz link <url>
+
+
+PANVIMDOC-INCLUDE-COMMENT-CONTENT     *test-panvimdoc-include-comment-content*
+
+Neovim is a great text editor.
+
+Neovim supports |lua| plugins and is also:
+
+- Multiplatform
+- Open source
+
+
+ALL CONTENT TYPES                                     *test-all-content-types*
+
+
+ARE SUPPORTED ~
+
+See neovim.org <https://neovim.org>.
 
 ==============================================================================
 3. Links                                                          *test-links*

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -395,11 +395,11 @@ bar
 
 [*foo* bar baz [link](url)]{.class #id key=val}
 
-## panvimdoc-include-comment-content
+## panvimdoc-include-comment
 
-<!-- panvimdoc-include-comment-content Neovim is a great text editor. -->
+<!-- panvimdoc-include-comment Neovim is a great text editor. -->
 
-<!-- panvimdoc-include-comment-content
+<!-- panvimdoc-include-comment
 
 Neovim supports `:h lua` plugins and is also:
 
@@ -783,7 +783,7 @@ BRACKETED SPANS                                         *test-bracketed-spans*
 _foo_ bar baz link <url>
 
 
-PANVIMDOC-INCLUDE-COMMENT-CONTENT     *test-panvimdoc-include-comment-content*
+PANVIMDOC-INCLUDE-COMMENT                     *test-panvimdoc-include-comment*
 
 Neovim is a great text editor.
 


### PR DESCRIPTION
The inverse of `<!-- panvimdoc-ignore-start/end -->`, where the content is only visible in the vimdoc output. Because we have no control on the mardown renderer, all content must be embedded in the comment, compared to using a start and end marker.

The test is written expecting #47 to be merged. 