### PR TITLE
Feature: add support for pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 -   id: panvimdoc
     name: pandoc to vimdoc
     description: Convert markdown documentation to vimdoc (using docker)
-    entry: /panvimdoc.sh
+    entry: /panvimdoc.pre-commit.sh
     language: docker
     files: ^README\.md$
     args:

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,10 @@
+-   id: panvimdoc
+    name: pandoc to vimdoc
+    description: Convert markdown documentation to vimdoc (using docker)
+    entry: /panvimdoc.sh
+    language: docker
+    files: ^README\.md$
+    args:
+    - --input-file
+    - README.md
+    pass_filenames: false

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,10 +1,20 @@
--   id: panvimdoc
-    name: pandoc to vimdoc
-    description: Convert markdown documentation to vimdoc (using docker)
-    entry: /panvimdoc.pre-commit.sh
-    language: docker
-    files: ^README\.md$
-    args:
-        - '--input-file'
-        - README.md
-    pass_filenames: false
+- id: panvimdoc-docker
+  name: pandoc to vimdoc (docker)
+  description: Convert markdown documentation to vimdoc (using docker)
+  entry: /panvimdoc.pre-commit.sh
+  language: docker
+  files: ^README\.md$
+  args:
+    - '--input-file'
+    - README.md
+  pass_filenames: false
+- id: panvimdoc
+  name: pandoc to vimdoc
+  description: Convert markdown documentation to vimdoc (using local environment)
+  entry: panvimdoc.pre-commit.sh
+  language: script
+  files: ^README\.md$
+  args:
+    - '--input-file'
+    - README.md
+  pass_filenames: false

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,6 +5,6 @@
     language: docker
     files: ^README\.md$
     args:
-    - --input-file
-    - README.md
+        - '--input-file'
+        - README.md
     pass_filenames: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,13 @@ RUN apk update && apk upgrade && apk add bash vim neovim
 
 # Copies your code file  repository to the filesystem
 COPY panvimdoc.sh /panvimdoc.sh
+COPY panvimdoc.pre-commit.sh /panvimdoc.pre-commit.sh
 COPY scripts/ /scripts/
 COPY lib/Demojify.lua /usr/share/lua/common/lib/Demojify.lua
 
 # change permission to execute the script and
 RUN chmod +x /panvimdoc.sh
+RUN chmod +x /panvimdoc.pre-commit.sh
 
 # file to execute when the docker container starts up
 ENTRYPOINT ["/panvimdoc.sh"]

--- a/README.md
+++ b/README.md
@@ -170,6 +170,38 @@ jobs:
 
 </details>
 
+### Using pre-commit
+[pre-commit](https://pre-commit.com/) lets you easily install and manage pre-commit hooks.
+
+First, install pre-commit. Then, add the following to your `.pre-commit-config.yaml`
+
+```yaml
+-   repo: <link-to-repo>
+    rev: d4327e1f
+    hooks:
+    -   id: panvimdoc
+        args:
+        - --project-name
+        - <your-project-name>
+```
+
+You can specify additional arguments to `panvimdoc.sh` using `args`. See the section below (or run `./panvimdoc.sh`) for the full list of arguments.
+
+To change the input file, modify the `files` field of the hook and supply the corresponding `--input-file` to `args`. In the example below, the hook will be triggered if any `.md` file changes:
+
+```yaml
+-   repo: <link-to-repo>
+    rev: d4327e1f
+    hooks:
+    -   id: panvimdoc
+        files: ^.*\.md$
+        args:
+        - --project-name
+        - <your-project-name>
+        - --input-file
+        - <your-input-file.md>
+```
+
 ### Using it manually
 
 The `./panvimdoc.sh` script runs `pandoc` along with all the filters and custom output writer.

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ jobs:
 First, install pre-commit. Then, add the following to your `.pre-commit-config.yaml`
 
 ```yaml
--   repo: <link-to-repo>
+-   repo: https://github.com/kdheepak/panvimdoc
     rev: d4327e1f
     hooks:
     -   id: panvimdoc

--- a/README.md
+++ b/README.md
@@ -171,17 +171,23 @@ jobs:
 </details>
 
 ### Using pre-commit
-[pre-commit](https://pre-commit.com/) lets you easily install and manage pre-commit hooks.
+[pre-commit](https://pre-commit.com/) lets you easily install and manage pre-commit hooks locally.
 
-First, install pre-commit. Then, add the following to your `.pre-commit-config.yaml`
+Two hooks are available, differing only in the way dependencies are handled:
+
+- `panvimdoc-docker`: Requires a running Docker engine on your host. All other dependencies will be loaded inside the container.
+- `panvimdoc`: Runs in your local environment, so you have to make sure all dependencies of panvimdoc are installed
+    (i.e., `pandoc v3.0.0` or greater)
+
+To use a hook, first install pre-commit. Then, add the following to your `.pre-commit-config.yaml` (here `panvimdoc-docker` is used):
 
 ```yaml
--   repo: https://github.com/kdheepak/panvimdoc
-    rev: d4327e1f
-    hooks:
-    -   id: panvimdoc
-        args:
-        - --project-name
+- repo: 'https://github.com/kdheepak/panvimdoc'
+  rev: v4.0.1
+  hooks:
+    - id: panvimdoc-docker
+      args:
+        - '--project-name'
         - <your-project-name>
 ```
 
@@ -190,15 +196,15 @@ You can specify additional arguments to `panvimdoc.sh` using `args`. See the sec
 To change the input file, modify the `files` field of the hook and supply the corresponding `--input-file` to `args`. In the example below, the hook will be triggered if any `.md` file changes:
 
 ```yaml
--   repo: <link-to-repo>
-    rev: d4327e1f
-    hooks:
-    -   id: panvimdoc
-        files: ^.*\.md$
-        args:
-        - --project-name
+- repo: 'https://github.com/kdhee'
+  rev: v4.0.1
+  hooks:
+    - id: panvimdoc-docker
+      files: ^.*\.md$
+      args:
+        - '--project-name'
         - <your-project-name>
-        - --input-file
+        - '--input-file'
         - <your-input-file.md>
 ```
 

--- a/panvimdoc.pre-commit.sh
+++ b/panvimdoc.pre-commit.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+args=$#                          # number of command line args
+for (( i=1; i<=$args; i+=2 ))    # loop from 1 to N (where N is number of args)
+do
+    j=$((i + 1 ))
+    if [ "${!i}" == "--project-name" ] ; then
+        PROJECT_NAME="${!j}"
+        break;
+    fi
+done
+
+# extract project name to determine file location
+if [ -z "$PROJECT_NAME" ]; then
+    echo "Error: argument --project-name is not set."
+    exit 1
+fi
+# store hash to check whether documentation has changed
+if [ -f "doc/$PROJECT_NAME.txt" ]; then
+    DOC_HASH_PRE="$(md5sum doc/$PROJECT_NAME.txt)"
+else
+    DOC_HASH_PRE=""
+fi
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "$SCRIPT_DIR/panvimdoc.sh"
+DOC_HASH_POST="$(md5sum doc/$PROJECT_NAME.txt)"
+# send FAIL when doc has changed
+if [ "$DOC_HASH_PRE" != "$DOC_HASH_POST" ] ; then
+    echo ""
+    echo 'Updated documentation "doc/$PROJECT_NAME.txt"'
+    echo 'Use "git add doc/$PROJECT_NAME.txt" to stage the changes'
+    exit 1
+fi


### PR DESCRIPTION
[pre-commit](https://pre-commit.com/) allows to easily configure pre-commit hooks. By adding a `.pre-commit-config`, panvimdoc can be easily integrated, allowing to conversion of the markdown files as a pre-commit hook.

This PR adds the corresponding file and a section in the README to document how to use it. The `rev` and `repo` fields can be adapted after the PR is merged, maybe a version tag can be added so it can be referenced using `rev`.

Thanks for building this tool, if you have any questions or suggestions, please let me know.