### PR TITLE
feat: Add option for setting date pattern 

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ jobs:
           version: "NVIM v0.8.0" # Vim version number
           toc: true # Table of contents
           description: "" # Project description used in title (if empty, uses neovim version and current date)
+          titledatepattern: "%Y %B %d" # Pattern for the date that used in the title
           demojify: false # Strip emojis from the vimdoc
           dedupsubheadings: true # Add heading to subheading anchor links to ensure that subheadings are unique
           treesitter: true # Use treesitter for highlighting codeblocks
@@ -185,6 +186,7 @@ Arguments:
   --toc: 'true' if the output should include a table of contents, 'false' otherwise
   --description: a project description used in title (if empty, uses neovim version and current date)
   --dedup-subheadings: 'true' if duplicate subheadings should be removed, 'false' otherwise
+  --title-date-pattern: '%Y %B %d' a pattern for the date that used in the title
   --demojify: 'false' if emojis should not be removed, 'true' otherwise
   --treesitter: 'true' if the project uses Tree-sitter syntax highlighting, 'false' otherwise
   --ignore-rawblocks: 'true' if the project should ignore HTML raw blocks, 'false' otherwise

--- a/action.yaml
+++ b/action.yaml
@@ -24,6 +24,10 @@ inputs:
     description: "Project description used in title (if empty, uses neovim version and current date)"
     required: false
     default: ""
+  description:
+    titledatepattern: "Pattern for the date that used in the title (if empty, uses '%Y %B %d')"
+    required: false
+    default: "%Y %B %d"
   demojify:
     description: "Strip emojis from the vimdoc"
     required: false
@@ -70,6 +74,8 @@ runs:
     - ${{ inputs.toc }}
     - --description
     - ${{ inputs.description }}
+    - --title-date-pattern
+    - ${{ inputs.titledatepattern }}
     - --dedup-subheadings
     - ${{ inputs.dedupsubheadings }}
     - --demojify

--- a/action.yaml
+++ b/action.yaml
@@ -24,8 +24,8 @@ inputs:
     description: "Project description used in title (if empty, uses neovim version and current date)"
     required: false
     default: ""
-  description:
-    titledatepattern: "Pattern for the date that used in the title (if empty, uses '%Y %B %d')"
+  titledatepattern:
+    description: "Pattern for the date that used in the title (if empty, uses '%Y %B %d')"
     required: false
     default: "%Y %B %d"
   demojify:

--- a/doc/panvimdoc.txt
+++ b/doc/panvimdoc.txt
@@ -137,6 +137,7 @@ Then add the following to `./.github/workflows/panvimdoc.yml`:
               version: "NVIM v0.8.0" # Vim version number
               toc: true # Table of contents
               description: "" # Project description used in title (if empty, uses neovim version and current date)
+              titledatepattern: "%Y %B %d" # Pattern for the date that used in the title
               demojify: false # Strip emojis from the vimdoc
               dedupsubheadings: true # Add heading to subheading anchor links to ensure that subheadings are unique
               treesitter: true # Use treesitter for highlighting codeblocks
@@ -234,6 +235,7 @@ output writer.
       --vim-version: the version of Vim that the project is compatible with
       --toc: 'true' if the output should include a table of contents, 'false' otherwise
       --description: a project description used in title (if empty, uses neovim version and current date)
+      --title-date-pattern: '%Y %B %d' a pattern for the date that used in the title
       --dedup-subheadings: 'true' if duplicate subheadings should be removed, 'false' otherwise
       --demojify: 'false' if emojis should not be removed, 'true' otherwise
       --treesitter: 'true' if the project uses Tree-sitter syntax highlighting, 'false' otherwise

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 build:
-    @./panvimdoc.sh "--project-name" "panvimdoc" "--input-file" "doc/panvimdoc.md" "--vim-version" "NVIM v0.8.0" "--toc" "true" "--description" "" "--dedup-subheadings" "true" "--demojify" "false" "--treesitter" "true" "--ignore-rawblocks" "true" "--doc-mapping" "false" "--doc-mapping-project-name" "true" --shift-heading-level-by 0 --increment-heading-level-by 0
+    @./panvimdoc.sh "--project-name" "panvimdoc" "--input-file" "doc/panvimdoc.md" "--vim-version" "NVIM v0.8.0" "--toc" "true" "--description" "" "--title-date-pattern" "%Y %B %d" "--dedup-subheadings" "true" "--demojify" "false" "--treesitter" "true" "--ignore-rawblocks" "true" "--doc-mapping" "false" "--doc-mapping-project-name" "true" --shift-heading-level-by 0 --increment-heading-level-by 0
 
 test:
   julia --project -e 'using Pkg; Pkg.test()'

--- a/panvimdoc.sh
+++ b/panvimdoc.sh
@@ -13,6 +13,7 @@ Arguments:
   --vim-version: the version of Vim that the project is compatible with
   --toc: 'true' if the output should include a table of contents, 'false' otherwise
   --description: a project description used in title (if empty, uses neovim version and current date)
+  --title-date-pattern: '%Y %B %d' a pattern for the date that used in the title
   --dedup-subheadings: 'true' if duplicate subheadings should be removed, 'false' otherwise
   --demojify: 'false' if emojis should not be removed, 'true' otherwise
   --treesitter: 'true' if the project uses Tree-sitter syntax highlighting, 'false' otherwise
@@ -48,6 +49,11 @@ while [[ $# -gt 0 ]]; do
         ;;
     --toc)
         TOC="$2"
+        shift # past argument
+        shift # past value
+        ;;
+    --title-date-pattern)
+        TITLE_DATE_PATTERN="$2"
         shift # past argument
         shift # past value
         ;;
@@ -135,6 +141,7 @@ ARGS=(
     "--metadata=vimversion:${VIM_VERSION:-""}"
     "--metadata=toc:${TOC:-true}"
     "--metadata=description:${DESCRIPTION:-""}"
+    "--metadata=titledatepattern:${TITLE_DATE_PATTERN:-"%Y %B %d"}"
     "--metadata=dedupsubheadings:${DEDUP_SUBHEADINGS:-true}"
     "--metadata=ignorerawblocks:${IGNORE_RAWBLOCKS:-true}"
     "--metadata=docmapping:${DOC_MAPPING:-false}"

--- a/scripts/panvimdoc.lua
+++ b/scripts/panvimdoc.lua
@@ -73,6 +73,7 @@ local IGNORE_RAWBLOCKS = true
 local DOC_MAPPING = true
 local DOC_MAPPING_PROJECT = true
 local DATE = nil
+local TITLE_DATE_PATTERN = "%Y %B %d"
 
 local CURRENT_HEADER = nil
 local SOFTBREAK_TO_HARDBREAK = "space"
@@ -116,7 +117,7 @@ local function renderTitle()
 
     local date = DATE
     if date == nil then
-      date = os.date("%Y %B %d")
+      date = os.date(TITLE_DATE_PATTERN)
     end
     local m = "For " .. vim_version
     local r = "Last change: " .. date
@@ -197,6 +198,7 @@ Writer.Pandoc = function(doc, opts)
   DOC_MAPPING_PROJECT = doc.meta.docmappingproject
   HEADER_COUNT = HEADER_COUNT + doc.meta.incrementheadinglevelby
   DATE = doc.meta.date
+  TITLE_DATE_PATTERN = doc.meta.titledatepattern
   local d = blocks(doc.blocks)
   local toc = renderToc()
   local notes = renderNotes()


### PR DESCRIPTION
It's an ability to set custom title's date pattern.

with github-action:
```yaml
      - name: panvimdoc
        uses: kdheepak/panvimdoc@main
        with:
          vimdoc: improved-search.nvim
          titledatepattern: "%Y"
```
with command line:
```bash
../panvimdoc/panvimdoc.sh --project-name "improved-search.nvim" --input-file ./README.md --title-date-pattern "%Y"
```

 I tested it manually with `panvimdoc.sh` and with action. It works with and without the flag as expected.
 
 Sorry for the late request