### PR TITLE
Fix a typo in the readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ vimdoc.
 
 <img width="1512" alt="image" src="https://github.com/kdheepak/panvimdoc/assets/1813121/dfaed08d-fb9b-4cac-aad0-da71b605265d">
 
-::: center This software is released under a MIT License. :::
+<div align="center">This software is released under a MIT License.</div>
 
 # TLDR
 


### PR DESCRIPTION
Center a line that was supposed to be centered, but wasn't.

I assumed this line was supposed to be centered:
`::: center This software is released under a MIT License. :::`