### PR TITLE
fix(emoji): don't remove single colons

### DIFF
--- a/doc/panvimdoc.txt
+++ b/doc/panvimdoc.txt
@@ -1,4 +1,4 @@
-*panvimdoc.txt*           For NVIM v0.8.0          Last change: 2025 August 08
+*panvimdoc.txt*         For NVIM v0.8.0         Last change: 2025 September 25
 
 ==============================================================================
 Table of Contents                                *panvimdoc-table-of-contents*

--- a/scripts/remove-emojis.lua
+++ b/scripts/remove-emojis.lua
@@ -29,7 +29,8 @@ local function cleanup(elem)
   if elem.text ~= nil then
     elem.text = demojify(elem.text)
     if #elem.text ~= 0 then
-      if elem.text:starts_with(":") and elem.text:ends_with(":") then
+      -- remove github emoji
+      if elem.text:starts_with(":") and elem.text:ends_with(":") and #elem.text > 2 then
         prevEmoji = true
         return {}
       else


### PR DESCRIPTION
The current implementation of remove-emojis.lua removes tokens in the pandoc tree that are just single or double colons. For example, the file
```
A : B
**A**: B
```
is transformed into
```
A B
**A**B
```

The shortest github emojis are 3 characters (including the colons), so removing anything shorter than that won't match them. By only removing strings that start & end with ":" and are at least 3 characters long, the output for situations like the example above is fixed and includes the colons.

To more accuractely remove only github emoji and no other tokens surrounded by colons, you could make use of https://api.github.com/emojis to get an up-to-date list, but that might be a bit overkill.
